### PR TITLE
Eng 649 add bucket_function passalong for minne

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,20 @@ Requires `ExAws.S3` and its dependencies.
 Will upload the file to S3 directly, never hitting the servers hardrive.
 
 ```elixir
-plug(Plug.Parsers,
-  parsers: [
-    {
-      Minne,
-      adapter: Minne.Adapter.S3
-      adapter_opts: [bucket: "some-bucket", upload_prefix: "upload"],
-    },
-    :urlencoded,
-    :json
-  ],
-  json_decoder: Jason
-)
+plug Plug.Parsers,
+       [
+         parsers: [
+           {Minne,
+            adapter: Minne.Adapter.S3,
+            adapter_opts: [
+              max_file_size: 1_000_000,
+              bucket_function: &MyModule.fetch_upload_bucket_name/0,
+              path_function: &MyModule.gen_upload_path/1
+            ]}
+         ],
+         pass: ["*/*"],
+         json_decoder: Phoenix.json_library()
+       ]
 ```
 
 ### Temp

--- a/lib/minne.ex
+++ b/lib/minne.ex
@@ -54,10 +54,12 @@ defmodule Minne do
     rescue
       # Do not ignore upload errors
       e in [Plug.UploadError, Plug.Parsers.BadEncodingError] ->
+        Logger.error("Minne: #{inspect(e)}")
         reraise e, __STACKTRACE__
 
       # All others are wrapped
       e ->
+        Logger.error("Minne: #{inspect(e)}")
         reraise Plug.Parsers.ParseError.exception(exception: e), __STACKTRACE__
     end
   end


### PR DESCRIPTION
This makes is so anyone using this library can just provide a function for fetching bucketname during runtime.